### PR TITLE
Unify links accorss Logux projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,10 +7,10 @@ Logux is a new way to connect client and server. Instead of sending
 HTTP requests (e.g., AJAX and GraphQL) it synchronizes log of operations
 between client, server, and other clients.
 
-* **[Guide and recipes](https://logux.io/)**
+* **[Guide, recipes and API](https://logux.io/)**
 * **[Chat](https://gitter.im/logux/logux)** for any questions
-* **[Issues and plans](https://github.com/logux/logux/issues)**
-* **[Projects](https://logux.io/architecture/parts/)** inside the Logux family
+* **[Issues and roadmap](https://github.com/logux/logux/issues)**
+* **[Projects](https://logux.io/architecture/parts/)** inside the Logux ecosystem
 
 This repository contains [Vuex] compatible API on top of [Logux Client].
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,10 @@ Logux is a new way to connect client and server. Instead of sending
 HTTP requests (e.g., AJAX and GraphQL) it synchronizes log of operations
 between client, server, and other clients.
 
-**Documentation: [logux.io]**
+* **[Guide and recipes](https://logux.io/)**
+* **[Chat](https://gitter.im/logux/logux)** for any questions
+* **[Issues and plans](https://github.com/logux/logux/issues)**
+* **[Projects](https://logux.io/architecture/parts/)** inside the Logux family
 
 This repository contains [Vuex] compatible API on top of [Logux Client].
 

--- a/README.md
+++ b/README.md
@@ -7,10 +7,11 @@ Logux is a new way to connect client and server. Instead of sending
 HTTP requests (e.g., AJAX and GraphQL) it synchronizes log of operations
 between client, server, and other clients.
 
-* **[Guide, recipes and API](https://logux.io/)**
+* **[Guide, recipes, and API](https://logux.io/)**
 * **[Chat](https://gitter.im/logux/logux)** for any questions
-* **[Issues and roadmap](https://github.com/logux/logux/issues)**
-* **[Projects](https://logux.io/architecture/parts/)** inside the Logux ecosystem
+* **[Issues](https://github.com/logux/logux/issues)**
+  and **[roadmap](https://github.com/logux/logux/projects/1)**
+* **[Projects](https://logux.io/architecture/parts/)** inside Logux ecosystem
 
 This repository contains [Vuex] compatible API on top of [Logux Client].
 

--- a/package.json
+++ b/package.json
@@ -111,7 +111,8 @@
       "TypeDoc",
       "WebSocket",
       "payload",
-      "ES"
+      "ES",
+      "roadmap"
     ]
   },
   "sharec": {


### PR DESCRIPTION
I updated the default links, which I used in all Logux repo (in most of repos they are under `next` branch for now).